### PR TITLE
Fix parsing error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+out

--- a/jsdoc_conf.json
+++ b/jsdoc_conf.json
@@ -1,0 +1,3 @@
+{
+    "plugins": ["lib/jsdoc-codesnippet"]
+}

--- a/lib/jsdoc-codesnippet.js
+++ b/lib/jsdoc-codesnippet.js
@@ -20,7 +20,7 @@ exports.handlers = {
 			if (doclet.description && doclet.description.indexOf("{@snippet ") > -1) {
 				doclet.description = doclet.description.replace(/{@snippet\s+(\w+?)(?:\s+(.*?))?}/g, function (matched, snippetCode, label) {
 					if (snippets[snippetCode]) {
-						return '<pre style="line-height: 1.25em;font-size: 0.9em;margin-top: 5px;border-left: 2px solid #eee;padding-left: 15px;margin-left: 10px;"">' + snippets[snippetCode].content.replace(new RegExp(doclet.name, "g"), '<span style="color: red">' + doclet.name + '</span>') + '</pre>';
+						return '\n<pre><code>\n' + snippets[snippetCode].content + '\n</code></pre>\n';
 					} else {
 						logger.error('Reference to inexistant snippet "' + snippetCode + '"');
 						return "";
@@ -41,16 +41,24 @@ exports.defineTags = function (dictionary) {
 	dictionary.defineTag("snippetStart", {
 		mustHaveValue: true,
 		onTagged: function onTagged(doclet, tag) {
+			// only include the last doclet tagged
+			if (!(doclet.meta.code && Object.keys(doclet.meta.code).length > 0)) {
+				return;
+			}
 			if (snippets[doclet.value] != null) {
 				logger.error('Redefinition of snippet name "' + doclet.value + '"');
 			} else {
-				snippets[tag.value] = { start: doclet.meta.range[1] };
+				snippets[tag.value] = { start: doclet.meta.range[0] };
 			}
 		}
 	});
 	dictionary.defineTag("snippetEnd", {
 		mustHaveValue: true,
 		onTagged: function onTagged(doclet, tag) {
+			// only include the first doclet tagged
+			if (!(doclet.meta.code && Object.keys(doclet.meta.code).length === 0)) {
+				return;
+			}
 			if (snippets[tag.value] == null) {
 				logger.error('End of snippet name "' + doclet.value + '" found before its beginning. Did you forget the "@snippetStart ' + doclet.value + '" doclet?');
 			} else {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "compile": "babel -d lib/ src/",
-    "prepublish": "npm run compile"
+    "prepublish": "npm run compile",
+    "test": "jsdoc -c jsdoc_conf.json tests/test_parse.js && comm -12 out/global.html tests/expected.js | diff -w - tests/expected.js"
   },
   "keywords": [
     "jsdoc",
@@ -29,7 +30,8 @@
   "devDependencies": {
     "babel": "^5.8.23",
     "babel-preset-es2015": "^6.6.0",
-    "babel-runtime": "^5.8.24"
+    "babel-runtime": "^5.8.24",
+    "jsdoc": "^3.4.3"
   },
   "babel": {
     "presets": [

--- a/src/jsdoc-codesnippet.js
+++ b/src/jsdoc-codesnippet.js
@@ -18,7 +18,7 @@ exports.handlers = {
 			if(doclet.description && doclet.description.indexOf("{@snippet ") > -1){
 				doclet.description = doclet.description.replace(/{@snippet\s+(\w+?)(?:\s+(.*?))?}/g, function(matched, snippetCode, label){
 					if(snippets[snippetCode]){
-						return `<pre style="line-height: 1.25em;font-size: 0.9em;margin-top: 5px;border-left: 2px solid #eee;padding-left: 15px;margin-left: 10px;"">${ snippets[snippetCode].content.replace(new RegExp(doclet.name,"g"), `<span style="color: red">${ doclet.name }</span>`) }</pre>`;
+						return `\n<pre><code>\n${ snippets[snippetCode].content }\n</code></pre>\n`;
 					} else {
 						logger.error(`Reference to inexistant snippet "${ snippetCode }"`);
 						return "";
@@ -40,16 +40,24 @@ exports.defineTags = function(dictionary) {
 	dictionary.defineTag("snippetStart",{
 		mustHaveValue:true,
 		onTagged: function(doclet, tag){
+			// only include the last doclet tagged
+			if (!(doclet.meta.code && Object.keys(doclet.meta.code).length > 0)) {
+				return;
+			}
 			if(snippets[doclet.value] != null){
 				logger.error(`Redefinition of snippet name "${ doclet.value }"`);
 			} else {
-				snippets[tag.value] = {start:doclet.meta.range[1]};
+				snippets[tag.value] = {start:doclet.meta.range[0]};
 			}
 		}
 	});
 	dictionary.defineTag("snippetEnd",{
 		mustHaveValue:true,
 		onTagged: function(doclet, tag){
+			// only include the first doclet tagged
+			if (!(doclet.meta.code && Object.keys(doclet.meta.code).length === 0)) {
+				return;
+			}
 			if(snippets[tag.value] == null){
 				logger.error(`End of snippet name "${ doclet.value }" found before its beginning. Did you forget the "@snippetStart ${ doclet.value }" doclet?`);
 			} else {

--- a/tests/expected.js
+++ b/tests/expected.js
@@ -1,0 +1,3 @@
+output = {
+    'hello': 'world'
+};

--- a/tests/test_parse.js
+++ b/tests/test_parse.js
@@ -1,0 +1,16 @@
+/**
+ * @snippetStart bar
+ */
+var output = {
+    'hello': 'world'
+};
+/**
+ * @snippetEnd bar
+ */
+
+/**
+ * @description Snippet: {@snippet bar}
+ */
+function testDocs() {
+    return;
+}


### PR DESCRIPTION
Thanks for the plugin!

Found this useful but unfortunately it didnt work with jsdoc 3 - so did a small update.

## Changes

- [x] Added small test to validate correctness
- [x] Ensure that we take the correct offset from the tags
- [x] Small output change to make output more generically consumable - e.g. works with `jsdoc2md`

